### PR TITLE
feat: add repository layer for BlockedApp, TimeSchedule, and GoalTask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^14.0.0",
         "expo": "~52.0.0",
         "expo-constants": "~17.0.0",
+        "expo-crypto": "~14.0.2",
         "expo-linking": "~7.0.0",
         "expo-router": "~4.0.0",
         "expo-sqlite": "~15.1.4",
@@ -7646,6 +7647,17 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-14.0.2.tgz",
+      "integrity": "sha512-WRc9PBpJraJN29VD5Ef7nCecxJmZNyRKcGkNiDQC1nhY5agppzwhqh7zEzNFarE/GqDgSiaDHS8yd5EgFhP9AQ==",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-font": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo/vector-icons": "^14.0.0",
     "expo": "~52.0.0",
     "expo-constants": "~17.0.0",
+    "expo-crypto": "~14.0.2",
     "expo-linking": "~7.0.0",
     "expo-router": "~4.0.0",
     "expo-sqlite": "~15.1.4",

--- a/src/app-blocking/blocking-types.ts
+++ b/src/app-blocking/blocking-types.ts
@@ -1,0 +1,11 @@
+export type EnforcementLevel = 'hard_block' | 'soft_warning' | 'off';
+
+export interface BlockedApp {
+  id: string;
+  packageName: string;
+  appName: string;
+  iconUri: string | null;
+  enforcementLevel: EnforcementLevel;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/database/repositories/blocked-app-repository.ts
+++ b/src/database/repositories/blocked-app-repository.ts
@@ -1,0 +1,101 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { BlockedApp, EnforcementLevel } from '../../app-blocking/blocking-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface BlockedAppRow {
+  id: string;
+  package_name: string;
+  app_name: string;
+  icon_uri: string | null;
+  enforcement_level: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRow(row: BlockedAppRow): BlockedApp {
+  return {
+    id: row.id,
+    packageName: row.package_name,
+    appName: row.app_name,
+    iconUri: row.icon_uri,
+    enforcementLevel: row.enforcement_level as EnforcementLevel,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getAll(db: SQLiteDatabase): Promise<BlockedApp[]> {
+  const rows = await db.getAllAsync<BlockedAppRow>('SELECT * FROM BlockedApp');
+  return rows.map(mapRow);
+}
+
+export async function getByPackageName(
+  db: SQLiteDatabase,
+  packageName: string
+): Promise<BlockedApp | null> {
+  const row = await db.getFirstAsync<BlockedAppRow>(
+    'SELECT * FROM BlockedApp WHERE package_name = ?',
+    packageName
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function getActivelyBlocked(
+  db: SQLiteDatabase
+): Promise<BlockedApp[]> {
+  const rows = await db.getAllAsync<BlockedAppRow>(
+    "SELECT * FROM BlockedApp WHERE enforcement_level != 'off'"
+  );
+  return rows.map(mapRow);
+}
+
+export async function upsert(
+  db: SQLiteDatabase,
+  app: Omit<BlockedApp, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<BlockedApp> {
+  const id = generateId();
+  const now = new Date().toISOString();
+
+  await db.runAsync(
+    `INSERT INTO BlockedApp (id, package_name, app_name, icon_uri, enforcement_level, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(package_name) DO UPDATE SET
+       app_name = excluded.app_name,
+       icon_uri = excluded.icon_uri,
+       enforcement_level = excluded.enforcement_level,
+       updated_at = excluded.updated_at`,
+    id,
+    app.packageName,
+    app.appName,
+    app.iconUri,
+    app.enforcementLevel,
+    now,
+    now
+  );
+
+  const row = await db.getFirstAsync<BlockedAppRow>(
+    'SELECT * FROM BlockedApp WHERE package_name = ?',
+    app.packageName
+  );
+  return mapRow(row!);
+}
+
+export async function updateEnforcement(
+  db: SQLiteDatabase,
+  id: string,
+  level: EnforcementLevel
+): Promise<void> {
+  await db.runAsync(
+    'UPDATE BlockedApp SET enforcement_level = ?, updated_at = ? WHERE id = ?',
+    level,
+    new Date().toISOString(),
+    id
+  );
+}
+
+export async function deleteById(
+  db: SQLiteDatabase,
+  id: string
+): Promise<void> {
+  await db.runAsync('DELETE FROM BlockedApp WHERE id = ?', id);
+}

--- a/src/database/repositories/goal-task-repository.ts
+++ b/src/database/repositories/goal-task-repository.ts
@@ -1,0 +1,132 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { GoalTask } from '../../task-management/task-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface GoalTaskRow {
+  id: string;
+  name: string;
+  date: string;
+  is_completed: number;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRow(row: GoalTaskRow): GoalTask {
+  return {
+    id: row.id,
+    name: row.name,
+    date: row.date,
+    isCompleted: row.is_completed === 1,
+    completedAt: row.completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getAll(db: SQLiteDatabase): Promise<GoalTask[]> {
+  const rows = await db.getAllAsync<GoalTaskRow>('SELECT * FROM GoalTask');
+  return rows.map(mapRow);
+}
+
+export async function getById(
+  db: SQLiteDatabase,
+  id: string
+): Promise<GoalTask | null> {
+  const row = await db.getFirstAsync<GoalTaskRow>(
+    'SELECT * FROM GoalTask WHERE id = ?',
+    id
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function getByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<GoalTask[]> {
+  const rows = await db.getAllAsync<GoalTaskRow>(
+    'SELECT * FROM GoalTask WHERE date = ?',
+    date
+  );
+  return rows.map(mapRow);
+}
+
+export async function getIncompleteByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<GoalTask[]> {
+  const rows = await db.getAllAsync<GoalTaskRow>(
+    'SELECT * FROM GoalTask WHERE date = ? AND is_completed = 0',
+    date
+  );
+  return rows.map(mapRow);
+}
+
+export async function create(
+  db: SQLiteDatabase,
+  task: Omit<GoalTask, 'id' | 'createdAt' | 'updatedAt' | 'completedAt' | 'isCompleted'>
+): Promise<GoalTask> {
+  const id = generateId();
+  const now = new Date().toISOString();
+
+  await db.runAsync(
+    `INSERT INTO GoalTask (id, name, date, is_completed, completed_at, created_at, updated_at)
+     VALUES (?, ?, ?, 0, NULL, ?, ?)`,
+    id,
+    task.name,
+    task.date,
+    now,
+    now
+  );
+
+  const row = await db.getFirstAsync<GoalTaskRow>(
+    'SELECT * FROM GoalTask WHERE id = ?',
+    id
+  );
+  return mapRow(row!);
+}
+
+export async function update(
+  db: SQLiteDatabase,
+  id: string,
+  updates: Partial<Pick<GoalTask, 'name' | 'isCompleted' | 'completedAt'>>
+): Promise<GoalTask> {
+  const setClauses: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (updates.name !== undefined) {
+    setClauses.push('name = ?');
+    params.push(updates.name);
+  }
+  if (updates.isCompleted !== undefined) {
+    setClauses.push('is_completed = ?');
+    params.push(updates.isCompleted ? 1 : 0);
+  }
+  if (updates.completedAt !== undefined) {
+    setClauses.push('completed_at = ?');
+    params.push(updates.completedAt);
+  }
+
+  const now = new Date().toISOString();
+  setClauses.push('updated_at = ?');
+  params.push(now);
+  params.push(id);
+
+  await db.runAsync(
+    `UPDATE GoalTask SET ${setClauses.join(', ')} WHERE id = ?`,
+    ...params
+  );
+
+  const row = await db.getFirstAsync<GoalTaskRow>(
+    'SELECT * FROM GoalTask WHERE id = ?',
+    id
+  );
+  return mapRow(row!);
+}
+
+export async function deleteById(
+  db: SQLiteDatabase,
+  id: string
+): Promise<void> {
+  await db.runAsync('DELETE FROM GoalTask WHERE id = ?', id);
+}

--- a/src/database/repositories/index.ts
+++ b/src/database/repositories/index.ts
@@ -1,0 +1,3 @@
+export * as blockedAppRepository from './blocked-app-repository';
+export * as timeScheduleRepository from './time-schedule-repository';
+export * as goalTaskRepository from './goal-task-repository';

--- a/src/database/repositories/time-schedule-repository.ts
+++ b/src/database/repositories/time-schedule-repository.ts
@@ -1,0 +1,153 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { TimeSchedule } from '../../task-management/task-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface TimeScheduleRow {
+  id: string;
+  name: string;
+  start_time: string;
+  end_time: string;
+  days_of_week: string;
+  is_active: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRow(row: TimeScheduleRow): TimeSchedule {
+  return {
+    id: row.id,
+    name: row.name,
+    startTime: row.start_time,
+    endTime: row.end_time,
+    daysOfWeek: JSON.parse(row.days_of_week) as number[],
+    isActive: row.is_active === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getAll(db: SQLiteDatabase): Promise<TimeSchedule[]> {
+  const rows = await db.getAllAsync<TimeScheduleRow>(
+    'SELECT * FROM TimeSchedule'
+  );
+  return rows.map(mapRow);
+}
+
+export async function getById(
+  db: SQLiteDatabase,
+  id: string
+): Promise<TimeSchedule | null> {
+  const row = await db.getFirstAsync<TimeScheduleRow>(
+    'SELECT * FROM TimeSchedule WHERE id = ?',
+    id
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function getActiveSchedules(
+  db: SQLiteDatabase
+): Promise<TimeSchedule[]> {
+  const rows = await db.getAllAsync<TimeScheduleRow>(
+    'SELECT * FROM TimeSchedule WHERE is_active = 1'
+  );
+  return rows.map(mapRow);
+}
+
+export async function isTimeBlocked(
+  db: SQLiteDatabase,
+  now: Date
+): Promise<boolean> {
+  const schedules = await getActiveSchedules(db);
+  const dayOfWeek = now.getDay();
+  const currentTime =
+    now.getHours().toString().padStart(2, '0') +
+    ':' +
+    now.getMinutes().toString().padStart(2, '0');
+
+  return schedules.some(
+    (s) =>
+      s.daysOfWeek.includes(dayOfWeek) &&
+      currentTime >= s.startTime &&
+      currentTime < s.endTime
+  );
+}
+
+export async function create(
+  db: SQLiteDatabase,
+  schedule: Omit<TimeSchedule, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<TimeSchedule> {
+  const id = generateId();
+  const now = new Date().toISOString();
+
+  await db.runAsync(
+    `INSERT INTO TimeSchedule (id, name, start_time, end_time, days_of_week, is_active, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    schedule.name,
+    schedule.startTime,
+    schedule.endTime,
+    JSON.stringify(schedule.daysOfWeek),
+    schedule.isActive ? 1 : 0,
+    now,
+    now
+  );
+
+  const row = await db.getFirstAsync<TimeScheduleRow>(
+    'SELECT * FROM TimeSchedule WHERE id = ?',
+    id
+  );
+  return mapRow(row!);
+}
+
+export async function update(
+  db: SQLiteDatabase,
+  id: string,
+  updates: Partial<Omit<TimeSchedule, 'id' | 'createdAt' | 'updatedAt'>>
+): Promise<TimeSchedule> {
+  const setClauses: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (updates.name !== undefined) {
+    setClauses.push('name = ?');
+    params.push(updates.name);
+  }
+  if (updates.startTime !== undefined) {
+    setClauses.push('start_time = ?');
+    params.push(updates.startTime);
+  }
+  if (updates.endTime !== undefined) {
+    setClauses.push('end_time = ?');
+    params.push(updates.endTime);
+  }
+  if (updates.daysOfWeek !== undefined) {
+    setClauses.push('days_of_week = ?');
+    params.push(JSON.stringify(updates.daysOfWeek));
+  }
+  if (updates.isActive !== undefined) {
+    setClauses.push('is_active = ?');
+    params.push(updates.isActive ? 1 : 0);
+  }
+
+  const now = new Date().toISOString();
+  setClauses.push('updated_at = ?');
+  params.push(now);
+  params.push(id);
+
+  await db.runAsync(
+    `UPDATE TimeSchedule SET ${setClauses.join(', ')} WHERE id = ?`,
+    ...params
+  );
+
+  const row = await db.getFirstAsync<TimeScheduleRow>(
+    'SELECT * FROM TimeSchedule WHERE id = ?',
+    id
+  );
+  return mapRow(row!);
+}
+
+export async function deleteById(
+  db: SQLiteDatabase,
+  id: string
+): Promise<void> {
+  await db.runAsync('DELETE FROM TimeSchedule WHERE id = ?', id);
+}

--- a/src/shared/uuid-utils.ts
+++ b/src/shared/uuid-utils.ts
@@ -1,0 +1,5 @@
+import * as Crypto from 'expo-crypto';
+
+export function generateId(): string {
+  return Crypto.randomUUID();
+}

--- a/src/task-management/task-types.ts
+++ b/src/task-management/task-types.ts
@@ -1,0 +1,20 @@
+export interface TimeSchedule {
+  id: string;
+  name: string;
+  startTime: string;
+  endTime: string;
+  daysOfWeek: number[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GoalTask {
+  id: string;
+  name: string;
+  date: string;
+  isCompleted: boolean;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/tests/database/repositories/blocked-app-repository.test.ts
+++ b/tests/database/repositories/blocked-app-repository.test.ts
@@ -1,0 +1,173 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-123'),
+}));
+
+import * as repo from '../../../src/database/repositories/blocked-app-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('BlockedAppRepository', () => {
+  const sampleRow = {
+    id: 'abc-123',
+    package_name: 'com.instagram.android',
+    app_name: 'Instagram',
+    icon_uri: '/icons/instagram.png',
+    enforcement_level: 'hard_block',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+
+  describe('getAll', () => {
+    it('returns all blocked apps mapped to camelCase', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getAll(mockDb);
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM BlockedApp'
+      );
+      expect(result).toEqual([
+        {
+          id: 'abc-123',
+          packageName: 'com.instagram.android',
+          appName: 'Instagram',
+          iconUri: '/icons/instagram.png',
+          enforcementLevel: 'hard_block',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns empty array when no apps exist', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const result = await repo.getAll(mockDb);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getByPackageName', () => {
+    it('returns the app when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.getByPackageName(
+        mockDb,
+        'com.instagram.android'
+      );
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM BlockedApp WHERE package_name = ?',
+        'com.instagram.android'
+      );
+      expect(result?.packageName).toBe('com.instagram.android');
+    });
+
+    it('returns null when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await repo.getByPackageName(mockDb, 'com.unknown');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getActivelyBlocked', () => {
+    it('returns apps where enforcement_level is not off', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getActivelyBlocked(mockDb);
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        "SELECT * FROM BlockedApp WHERE enforcement_level != 'off'"
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].enforcementLevel).toBe('hard_block');
+    });
+  });
+
+  describe('upsert', () => {
+    it('inserts a new app and returns it', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-123',
+      });
+
+      const result = await repo.upsert(mockDb, {
+        packageName: 'com.instagram.android',
+        appName: 'Instagram',
+        iconUri: '/icons/instagram.png',
+        enforcementLevel: 'hard_block',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO BlockedApp'),
+        'test-uuid-123',
+        'com.instagram.android',
+        'Instagram',
+        '/icons/instagram.png',
+        'hard_block',
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT(package_name) DO UPDATE'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+      expect(result.packageName).toBe('com.instagram.android');
+    });
+  });
+
+  describe('updateEnforcement', () => {
+    it('updates the enforcement level and timestamp', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+
+      await repo.updateEnforcement(mockDb, 'abc-123', 'soft_warning');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE BlockedApp SET enforcement_level = ?, updated_at = ? WHERE id = ?',
+        'soft_warning',
+        expect.any(String),
+        'abc-123'
+      );
+    });
+  });
+
+  describe('deleteById', () => {
+    it('deletes the app by id', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+
+      await repo.deleteById(mockDb, 'abc-123');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        'DELETE FROM BlockedApp WHERE id = ?',
+        'abc-123'
+      );
+    });
+  });
+});

--- a/tests/database/repositories/goal-task-repository.test.ts
+++ b/tests/database/repositories/goal-task-repository.test.ts
@@ -1,0 +1,209 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-789'),
+}));
+
+import * as repo from '../../../src/database/repositories/goal-task-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GoalTaskRepository', () => {
+  const sampleRow = {
+    id: 'task-1',
+    name: 'Finish coding',
+    date: '2026-01-07',
+    is_completed: 0,
+    completed_at: null,
+    created_at: '2026-01-07T08:00:00.000Z',
+    updated_at: '2026-01-07T08:00:00.000Z',
+  };
+
+  describe('getAll', () => {
+    it('returns all tasks mapped to camelCase', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getAll(mockDb);
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM GoalTask'
+      );
+      expect(result).toEqual([
+        {
+          id: 'task-1',
+          name: 'Finish coding',
+          date: '2026-01-07',
+          isCompleted: false,
+          completedAt: null,
+          createdAt: '2026-01-07T08:00:00.000Z',
+          updatedAt: '2026-01-07T08:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns empty array when no tasks exist', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const result = await repo.getAll(mockDb);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the task when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.getById(mockDb, 'task-1');
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM GoalTask WHERE id = ?',
+        'task-1'
+      );
+      expect(result?.name).toBe('Finish coding');
+    });
+
+    it('returns null when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await repo.getById(mockDb, 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getByDate', () => {
+    it('returns tasks for the given date', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getByDate(mockDb, '2026-01-07');
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM GoalTask WHERE date = ?',
+        '2026-01-07'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-01-07');
+    });
+  });
+
+  describe('getIncompleteByDate', () => {
+    it('returns only incomplete tasks for the given date', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getIncompleteByDate(mockDb, '2026-01-07');
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM GoalTask WHERE date = ? AND is_completed = 0',
+        '2026-01-07'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].isCompleted).toBe(false);
+    });
+
+    it('returns empty array when all tasks are complete', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const result = await repo.getIncompleteByDate(mockDb, '2026-01-07');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('create', () => {
+    it('inserts a task with isCompleted=false and completedAt=null', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-789',
+      });
+
+      const result = await repo.create(mockDb, {
+        name: 'Finish coding',
+        date: '2026-01-07',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO GoalTask'),
+        'test-uuid-789',
+        'Finish coding',
+        '2026-01-07',
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(result.isCompleted).toBe(false);
+      expect(result.completedAt).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('marks a task as completed', async () => {
+      const completedAt = '2026-01-07T15:00:00.000Z';
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        is_completed: 1,
+        completed_at: completedAt,
+      });
+
+      const result = await repo.update(mockDb, 'task-1', {
+        isCompleted: true,
+        completedAt,
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE GoalTask SET'),
+        1,
+        completedAt,
+        expect.any(String),
+        'task-1'
+      );
+      expect(result.isCompleted).toBe(true);
+      expect(result.completedAt).toBe(completedAt);
+    });
+
+    it('updates the task name', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        name: 'Updated task name',
+      });
+
+      const result = await repo.update(mockDb, 'task-1', {
+        name: 'Updated task name',
+      });
+
+      expect(result.name).toBe('Updated task name');
+    });
+  });
+
+  describe('deleteById', () => {
+    it('deletes the task by id', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+
+      await repo.deleteById(mockDb, 'task-1');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        'DELETE FROM GoalTask WHERE id = ?',
+        'task-1'
+      );
+    });
+  });
+});

--- a/tests/database/repositories/time-schedule-repository.test.ts
+++ b/tests/database/repositories/time-schedule-repository.test.ts
@@ -1,0 +1,203 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-456'),
+}));
+
+import * as repo from '../../../src/database/repositories/time-schedule-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('TimeScheduleRepository', () => {
+  const sampleRow = {
+    id: 'sched-1',
+    name: 'Work Hours',
+    start_time: '09:00',
+    end_time: '17:00',
+    days_of_week: '[1,2,3,4,5]',
+    is_active: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+
+  describe('getAll', () => {
+    it('returns all schedules mapped to camelCase with parsed daysOfWeek', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getAll(mockDb);
+
+      expect(result).toEqual([
+        {
+          id: 'sched-1',
+          name: 'Work Hours',
+          startTime: '09:00',
+          endTime: '17:00',
+          daysOfWeek: [1, 2, 3, 4, 5],
+          isActive: true,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ]);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the schedule when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.getById(mockDb, 'sched-1');
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM TimeSchedule WHERE id = ?',
+        'sched-1'
+      );
+      expect(result?.name).toBe('Work Hours');
+    });
+
+    it('returns null when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await repo.getById(mockDb, 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getActiveSchedules', () => {
+    it('returns only active schedules', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getActiveSchedules(mockDb);
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM TimeSchedule WHERE is_active = 1'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].isActive).toBe(true);
+    });
+  });
+
+  describe('isTimeBlocked', () => {
+    it('returns true when current time falls within an active schedule', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      // Wednesday (day 3) at 12:00
+      const now = new Date('2026-01-07T12:00:00');
+
+      const result = await repo.isTimeBlocked(mockDb, now);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when current time is outside schedule hours', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      // Wednesday (day 3) at 18:00 — after end_time 17:00
+      const now = new Date('2026-01-07T18:00:00');
+
+      const result = await repo.isTimeBlocked(mockDb, now);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when current day is not in schedule', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      // Sunday (day 0) at 12:00 — not in [1,2,3,4,5]
+      const now = new Date('2026-01-04T12:00:00');
+
+      const result = await repo.isTimeBlocked(mockDb, now);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no active schedules exist', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const now = new Date('2026-01-07T12:00:00');
+
+      const result = await repo.isTimeBlocked(mockDb, now);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('create', () => {
+    it('inserts a schedule and returns it', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-456',
+      });
+
+      const result = await repo.create(mockDb, {
+        name: 'Work Hours',
+        startTime: '09:00',
+        endTime: '17:00',
+        daysOfWeek: [1, 2, 3, 4, 5],
+        isActive: true,
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO TimeSchedule'),
+        'test-uuid-456',
+        'Work Hours',
+        '09:00',
+        '17:00',
+        '[1,2,3,4,5]',
+        1,
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(result.name).toBe('Work Hours');
+      expect(result.daysOfWeek).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe('update', () => {
+    it('updates specified fields and returns the updated schedule', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        name: 'Updated Name',
+      });
+
+      const result = await repo.update(mockDb, 'sched-1', {
+        name: 'Updated Name',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE TimeSchedule SET'),
+        'Updated Name',
+        expect.any(String),
+        'sched-1'
+      );
+      expect(result.name).toBe('Updated Name');
+    });
+  });
+
+  describe('deleteById', () => {
+    it('deletes the schedule by id', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+
+      await repo.deleteById(mockDb, 'sched-1');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        'DELETE FROM TimeSchedule WHERE id = ?',
+        'sched-1'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `expo-crypto` dependency and `src/shared/uuid-utils.ts` for UUID generation
- Creates domain types: `BlockedApp`, `EnforcementLevel`, `TimeSchedule`, `GoalTask`
- Implements three repositories with full CRUD, snake_case/camelCase mapping, and query filters (upsert with ON CONFLICT, isTimeBlocked evaluation, date/completion queries)
- Adds 30 tests across three repository test files

Closes #31

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 71 tests pass (30 new + 41 existing)
- [x] `npx eslint . --ext .ts,.tsx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)