### PR TITLE
feat: add repository layer for remaining models and shared utilities

### DIFF
--- a/src/calendar-tracking/calendar-types.ts
+++ b/src/calendar-tracking/calendar-types.ts
@@ -1,0 +1,32 @@
+export type DailyStatus = 'full_success' | 'partial_success' | 'not_met';
+
+export interface SuccessThreshold {
+  id: string;
+  date: string;
+  requiredCount: number;
+  totalCount: number;
+  createdAt: string;
+}
+
+export interface OverrideEvent {
+  id: string;
+  packageName: string;
+  appName: string;
+  timestamp: string;
+  date: string;
+  activeScheduleId: string | null;
+  taskContext: string | null;
+}
+
+export interface DailyRecord {
+  id: string;
+  date: string;
+  goalTasksCompleted: number;
+  goalTasksTotal: number;
+  successThreshold: number;
+  overrideCount: number;
+  timeScheduleAdherence: number;
+  status: DailyStatus;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/database/repositories/daily-record-repository.ts
+++ b/src/database/repositories/daily-record-repository.ts
@@ -1,0 +1,92 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { DailyRecord, DailyStatus } from '../../calendar-tracking/calendar-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface DailyRecordRow {
+  id: string;
+  date: string;
+  goal_tasks_completed: number;
+  goal_tasks_total: number;
+  success_threshold: number;
+  override_count: number;
+  time_schedule_adherence: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRow(row: DailyRecordRow): DailyRecord {
+  return {
+    id: row.id,
+    date: row.date,
+    goalTasksCompleted: row.goal_tasks_completed,
+    goalTasksTotal: row.goal_tasks_total,
+    successThreshold: row.success_threshold,
+    overrideCount: row.override_count,
+    timeScheduleAdherence: row.time_schedule_adherence,
+    status: row.status as DailyStatus,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function getByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<DailyRecord | null> {
+  const row = await db.getFirstAsync<DailyRecordRow>(
+    'SELECT * FROM DailyRecord WHERE date = ?',
+    date
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function upsert(
+  db: SQLiteDatabase,
+  record: Omit<DailyRecord, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<DailyRecord> {
+  const id = generateId();
+  const now = new Date().toISOString();
+
+  await db.runAsync(
+    `INSERT INTO DailyRecord (id, date, goal_tasks_completed, goal_tasks_total, success_threshold, override_count, time_schedule_adherence, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET
+       goal_tasks_completed = excluded.goal_tasks_completed,
+       goal_tasks_total = excluded.goal_tasks_total,
+       success_threshold = excluded.success_threshold,
+       override_count = excluded.override_count,
+       time_schedule_adherence = excluded.time_schedule_adherence,
+       status = excluded.status,
+       updated_at = excluded.updated_at`,
+    id,
+    record.date,
+    record.goalTasksCompleted,
+    record.goalTasksTotal,
+    record.successThreshold,
+    record.overrideCount,
+    record.timeScheduleAdherence,
+    record.status,
+    now,
+    now
+  );
+
+  const row = await db.getFirstAsync<DailyRecordRow>(
+    'SELECT * FROM DailyRecord WHERE date = ?',
+    record.date
+  );
+  return mapRow(row!);
+}
+
+export async function getByDateRange(
+  db: SQLiteDatabase,
+  startDate: string,
+  endDate: string
+): Promise<DailyRecord[]> {
+  const rows = await db.getAllAsync<DailyRecordRow>(
+    'SELECT * FROM DailyRecord WHERE date >= ? AND date <= ? ORDER BY date',
+    startDate,
+    endDate
+  );
+  return rows.map(mapRow);
+}

--- a/src/database/repositories/index.ts
+++ b/src/database/repositories/index.ts
@@ -1,3 +1,7 @@
 export * as blockedAppRepository from './blocked-app-repository';
 export * as timeScheduleRepository from './time-schedule-repository';
 export * as goalTaskRepository from './goal-task-repository';
+export * as successThresholdRepository from './success-threshold-repository';
+export * as overrideEventRepository from './override-event-repository';
+export * as dailyRecordRepository from './daily-record-repository';
+export * as userSettingsRepository from './user-settings-repository';

--- a/src/database/repositories/override-event-repository.ts
+++ b/src/database/repositories/override-event-repository.ts
@@ -1,0 +1,72 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { OverrideEvent } from '../../calendar-tracking/calendar-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface OverrideEventRow {
+  id: string;
+  package_name: string;
+  app_name: string;
+  timestamp: string;
+  date: string;
+  active_schedule_id: string | null;
+  task_context: string | null;
+}
+
+function mapRow(row: OverrideEventRow): OverrideEvent {
+  return {
+    id: row.id,
+    packageName: row.package_name,
+    appName: row.app_name,
+    timestamp: row.timestamp,
+    date: row.date,
+    activeScheduleId: row.active_schedule_id,
+    taskContext: row.task_context,
+  };
+}
+
+export async function create(
+  db: SQLiteDatabase,
+  event: Omit<OverrideEvent, 'id'>
+): Promise<OverrideEvent> {
+  const id = generateId();
+
+  await db.runAsync(
+    `INSERT INTO OverrideEvent (id, package_name, app_name, timestamp, date, active_schedule_id, task_context)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    event.packageName,
+    event.appName,
+    event.timestamp,
+    event.date,
+    event.activeScheduleId,
+    event.taskContext
+  );
+
+  const row = await db.getFirstAsync<OverrideEventRow>(
+    'SELECT * FROM OverrideEvent WHERE id = ?',
+    id
+  );
+  return mapRow(row!);
+}
+
+export async function getByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<OverrideEvent[]> {
+  const rows = await db.getAllAsync<OverrideEventRow>(
+    'SELECT * FROM OverrideEvent WHERE date = ?',
+    date
+  );
+  return rows.map(mapRow);
+}
+
+export async function getCountByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<number> {
+  const result = await db.getFirstAsync<{ count: number }>(
+    'SELECT COUNT(*) as count FROM OverrideEvent WHERE date = ?',
+    date
+  );
+  return result!.count;
+}

--- a/src/database/repositories/success-threshold-repository.ts
+++ b/src/database/repositories/success-threshold-repository.ts
@@ -1,0 +1,59 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { SuccessThreshold } from '../../calendar-tracking/calendar-types';
+import { generateId } from '../../shared/uuid-utils';
+
+interface SuccessThresholdRow {
+  id: string;
+  date: string;
+  required_count: number;
+  total_count: number;
+  created_at: string;
+}
+
+function mapRow(row: SuccessThresholdRow): SuccessThreshold {
+  return {
+    id: row.id,
+    date: row.date,
+    requiredCount: row.required_count,
+    totalCount: row.total_count,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getByDate(
+  db: SQLiteDatabase,
+  date: string
+): Promise<SuccessThreshold | null> {
+  const row = await db.getFirstAsync<SuccessThresholdRow>(
+    'SELECT * FROM SuccessThreshold WHERE date = ?',
+    date
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function upsert(
+  db: SQLiteDatabase,
+  threshold: Omit<SuccessThreshold, 'id' | 'createdAt'>
+): Promise<SuccessThreshold> {
+  const id = generateId();
+  const now = new Date().toISOString();
+
+  await db.runAsync(
+    `INSERT INTO SuccessThreshold (id, date, required_count, total_count, created_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET
+       required_count = excluded.required_count,
+       total_count = excluded.total_count`,
+    id,
+    threshold.date,
+    threshold.requiredCount,
+    threshold.totalCount,
+    now
+  );
+
+  const row = await db.getFirstAsync<SuccessThresholdRow>(
+    'SELECT * FROM SuccessThreshold WHERE date = ?',
+    threshold.date
+  );
+  return mapRow(row!);
+}

--- a/src/database/repositories/user-settings-repository.ts
+++ b/src/database/repositories/user-settings-repository.ts
@@ -1,0 +1,81 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { UserSettings } from '../../settings/settings-types';
+import { DatabaseError } from '../../shared/error-types';
+
+interface UserSettingsRow {
+  id: string;
+  day_reset_time: string;
+  onboarding_survey_response: string | null;
+  onboarding_completed: number;
+  global_blocking_enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapRow(row: UserSettingsRow): UserSettings {
+  return {
+    id: row.id,
+    dayResetTime: row.day_reset_time,
+    onboardingSurveyResponse: row.onboarding_survey_response,
+    onboardingCompleted: row.onboarding_completed === 1,
+    globalBlockingEnabled: row.global_blocking_enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function get(db: SQLiteDatabase): Promise<UserSettings> {
+  const row = await db.getFirstAsync<UserSettingsRow>(
+    'SELECT * FROM UserSettings WHERE id = ?',
+    '1'
+  );
+  if (!row) {
+    throw new DatabaseError('UserSettings record not found');
+  }
+  return mapRow(row);
+}
+
+export async function update(
+  db: SQLiteDatabase,
+  settings: Partial<
+    Pick<
+      UserSettings,
+      | 'dayResetTime'
+      | 'onboardingSurveyResponse'
+      | 'onboardingCompleted'
+      | 'globalBlockingEnabled'
+    >
+  >
+): Promise<UserSettings> {
+  const setClauses: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (settings.dayResetTime !== undefined) {
+    setClauses.push('day_reset_time = ?');
+    params.push(settings.dayResetTime);
+  }
+  if (settings.onboardingSurveyResponse !== undefined) {
+    setClauses.push('onboarding_survey_response = ?');
+    params.push(settings.onboardingSurveyResponse);
+  }
+  if (settings.onboardingCompleted !== undefined) {
+    setClauses.push('onboarding_completed = ?');
+    params.push(settings.onboardingCompleted ? 1 : 0);
+  }
+  if (settings.globalBlockingEnabled !== undefined) {
+    setClauses.push('global_blocking_enabled = ?');
+    params.push(settings.globalBlockingEnabled ? 1 : 0);
+  }
+
+  const now = new Date().toISOString();
+  setClauses.push('updated_at = ?');
+  params.push(now);
+  params.push('1');
+
+  await db.runAsync(
+    `UPDATE UserSettings SET ${setClauses.join(', ')} WHERE id = ?`,
+    ...params
+  );
+
+  return get(db);
+}

--- a/src/settings/settings-types.ts
+++ b/src/settings/settings-types.ts
@@ -1,0 +1,9 @@
+export interface UserSettings {
+  id: string;
+  dayResetTime: string;
+  onboardingSurveyResponse: string | null;
+  onboardingCompleted: boolean;
+  globalBlockingEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/shared/date-utils.ts
+++ b/src/shared/date-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Returns the aligned date as YYYY-MM-DD based on the reset time.
+ * If the time-of-day is before the reset time, returns the previous day.
+ */
+export function getAlignedDate(timestamp: Date, resetTime: string): string {
+  const hours = timestamp.getHours();
+  const minutes = timestamp.getMinutes();
+  const currentTime =
+    hours.toString().padStart(2, '0') +
+    ':' +
+    minutes.toString().padStart(2, '0');
+
+  if (currentTime < resetTime) {
+    const previousDay = new Date(timestamp);
+    previousDay.setDate(previousDay.getDate() - 1);
+    return formatDate(previousDay);
+  }
+
+  return formatDate(timestamp);
+}
+
+/**
+ * Formats a Date as YYYY-MM-DD.
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/src/shared/error-types.ts
+++ b/src/shared/error-types.ts
@@ -1,0 +1,35 @@
+export class DatabaseError extends Error {
+  readonly code = 'DATABASE_ERROR';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'DatabaseError';
+  }
+}
+
+export class ValidationError extends Error {
+  readonly code = 'VALIDATION_ERROR';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'ValidationError';
+  }
+}
+
+export class PermissionError extends Error {
+  readonly code = 'PERMISSION_ERROR';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'PermissionError';
+  }
+}
+
+export class NativeBridgeError extends Error {
+  readonly code = 'NATIVE_BRIDGE_ERROR';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'NativeBridgeError';
+  }
+}

--- a/tests/database/repositories/daily-record-repository.test.ts
+++ b/tests/database/repositories/daily-record-repository.test.ts
@@ -1,0 +1,149 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-123'),
+}));
+
+import * as repo from '../../../src/database/repositories/daily-record-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DailyRecordRepository', () => {
+  const sampleRow = {
+    id: 'rec-1',
+    date: '2026-01-15',
+    goal_tasks_completed: 3,
+    goal_tasks_total: 5,
+    success_threshold: 3,
+    override_count: 2,
+    time_schedule_adherence: 0.85,
+    status: 'partial_success',
+    created_at: '2026-01-15T00:00:00.000Z',
+    updated_at: '2026-01-15T23:59:00.000Z',
+  };
+
+  describe('getByDate', () => {
+    it('returns the record when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.getByDate(mockDb, '2026-01-15');
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM DailyRecord WHERE date = ?',
+        '2026-01-15'
+      );
+      expect(result).toEqual({
+        id: 'rec-1',
+        date: '2026-01-15',
+        goalTasksCompleted: 3,
+        goalTasksTotal: 5,
+        successThreshold: 3,
+        overrideCount: 2,
+        timeScheduleAdherence: 0.85,
+        status: 'partial_success',
+        createdAt: '2026-01-15T00:00:00.000Z',
+        updatedAt: '2026-01-15T23:59:00.000Z',
+      });
+    });
+
+    it('returns null when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await repo.getByDate(mockDb, '2026-01-16');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('upsert', () => {
+    it('inserts a new record and returns it', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-123',
+      });
+
+      const result = await repo.upsert(mockDb, {
+        date: '2026-01-15',
+        goalTasksCompleted: 3,
+        goalTasksTotal: 5,
+        successThreshold: 3,
+        overrideCount: 2,
+        timeScheduleAdherence: 0.85,
+        status: 'partial_success',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO DailyRecord'),
+        'test-uuid-123',
+        '2026-01-15',
+        3,
+        5,
+        3,
+        2,
+        0.85,
+        'partial_success',
+        expect.any(String),
+        expect.any(String)
+      );
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT(date) DO UPDATE'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+      expect(result.goalTasksCompleted).toBe(3);
+      expect(result.status).toBe('partial_success');
+    });
+  });
+
+  describe('getByDateRange', () => {
+    it('returns records within the date range ordered by date', async () => {
+      const row2 = { ...sampleRow, id: 'rec-2', date: '2026-01-16' };
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow, row2]);
+
+      const result = await repo.getByDateRange(
+        mockDb,
+        '2026-01-15',
+        '2026-01-16'
+      );
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM DailyRecord WHERE date >= ? AND date <= ? ORDER BY date',
+        '2026-01-15',
+        '2026-01-16'
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].date).toBe('2026-01-15');
+      expect(result[1].date).toBe('2026-01-16');
+    });
+
+    it('returns empty array when no records in range', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const result = await repo.getByDateRange(
+        mockDb,
+        '2026-02-01',
+        '2026-02-28'
+      );
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/tests/database/repositories/override-event-repository.test.ts
+++ b/tests/database/repositories/override-event-repository.test.ts
@@ -1,0 +1,107 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-123'),
+}));
+
+import * as repo from '../../../src/database/repositories/override-event-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('OverrideEventRepository', () => {
+  const sampleRow = {
+    id: 'evt-1',
+    package_name: 'com.instagram.android',
+    app_name: 'Instagram',
+    timestamp: '2026-01-15T10:30:00.000Z',
+    date: '2026-01-15',
+    active_schedule_id: 'sched-1',
+    task_context: 'goal-task-1',
+  };
+
+  describe('create', () => {
+    it('inserts a new override event and returns it', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-123',
+      });
+
+      const result = await repo.create(mockDb, {
+        packageName: 'com.instagram.android',
+        appName: 'Instagram',
+        timestamp: '2026-01-15T10:30:00.000Z',
+        date: '2026-01-15',
+        activeScheduleId: 'sched-1',
+        taskContext: 'goal-task-1',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO OverrideEvent'),
+        'test-uuid-123',
+        'com.instagram.android',
+        'Instagram',
+        '2026-01-15T10:30:00.000Z',
+        '2026-01-15',
+        'sched-1',
+        'goal-task-1'
+      );
+      expect(result.packageName).toBe('com.instagram.android');
+      expect(result.activeScheduleId).toBe('sched-1');
+    });
+  });
+
+  describe('getByDate', () => {
+    it('returns all events for a given date', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([sampleRow]);
+
+      const result = await repo.getByDate(mockDb, '2026-01-15');
+
+      expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+        'SELECT * FROM OverrideEvent WHERE date = ?',
+        '2026-01-15'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].packageName).toBe('com.instagram.android');
+    });
+
+    it('returns empty array when no events exist', async () => {
+      (mockDb.getAllAsync as jest.Mock).mockResolvedValue([]);
+
+      const result = await repo.getByDate(mockDb, '2026-01-16');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getCountByDate', () => {
+    it('returns the count of events for a given date', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({ count: 5 });
+
+      const result = await repo.getCountByDate(mockDb, '2026-01-15');
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT COUNT(*) as count FROM OverrideEvent WHERE date = ?',
+        '2026-01-15'
+      );
+      expect(result).toBe(5);
+    });
+
+    it('returns 0 when no events exist', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({ count: 0 });
+
+      const result = await repo.getCountByDate(mockDb, '2026-01-16');
+      expect(result).toBe(0);
+    });
+  });
+});

--- a/tests/database/repositories/success-threshold-repository.test.ts
+++ b/tests/database/repositories/success-threshold-repository.test.ts
@@ -1,0 +1,92 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+
+jest.mock('../../../src/shared/uuid-utils', () => ({
+  generateId: jest.fn(() => 'test-uuid-123'),
+}));
+
+import * as repo from '../../../src/database/repositories/success-threshold-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SuccessThresholdRepository', () => {
+  const sampleRow = {
+    id: 'thresh-1',
+    date: '2026-01-15',
+    required_count: 3,
+    total_count: 5,
+    created_at: '2026-01-15T00:00:00.000Z',
+  };
+
+  describe('getByDate', () => {
+    it('returns the threshold when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.getByDate(mockDb, '2026-01-15');
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM SuccessThreshold WHERE date = ?',
+        '2026-01-15'
+      );
+      expect(result).toEqual({
+        id: 'thresh-1',
+        date: '2026-01-15',
+        requiredCount: 3,
+        totalCount: 5,
+        createdAt: '2026-01-15T00:00:00.000Z',
+      });
+    });
+
+    it('returns null when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      const result = await repo.getByDate(mockDb, '2026-01-16');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('upsert', () => {
+    it('inserts a new threshold and returns it', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 1,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        id: 'test-uuid-123',
+      });
+
+      const result = await repo.upsert(mockDb, {
+        date: '2026-01-15',
+        requiredCount: 3,
+        totalCount: 5,
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO SuccessThreshold'),
+        'test-uuid-123',
+        '2026-01-15',
+        3,
+        5,
+        expect.any(String)
+      );
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT(date) DO UPDATE'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+      expect(result.requiredCount).toBe(3);
+      expect(result.totalCount).toBe(5);
+    });
+  });
+});

--- a/tests/database/repositories/user-settings-repository.test.ts
+++ b/tests/database/repositories/user-settings-repository.test.ts
@@ -1,0 +1,131 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import { DatabaseError } from '../../../src/shared/error-types';
+
+import * as repo from '../../../src/database/repositories/user-settings-repository';
+
+const mockDb = {
+  getAllAsync: jest.fn(),
+  getFirstAsync: jest.fn(),
+  runAsync: jest.fn(),
+} as unknown as jest.Mocked<SQLiteDatabase>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('UserSettingsRepository', () => {
+  const sampleRow = {
+    id: '1',
+    day_reset_time: '04:00',
+    onboarding_survey_response: '{"q1":"a"}',
+    onboarding_completed: 1,
+    global_blocking_enabled: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+
+  describe('get', () => {
+    it('returns settings when found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(sampleRow);
+
+      const result = await repo.get(mockDb);
+
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+        'SELECT * FROM UserSettings WHERE id = ?',
+        '1'
+      );
+      expect(result).toEqual({
+        id: '1',
+        dayResetTime: '04:00',
+        onboardingSurveyResponse: '{"q1":"a"}',
+        onboardingCompleted: true,
+        globalBlockingEnabled: true,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('throws DatabaseError when not found', async () => {
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue(null);
+
+      await expect(repo.get(mockDb)).rejects.toThrow(DatabaseError);
+      await expect(repo.get(mockDb)).rejects.toThrow(
+        'UserSettings record not found'
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates partial fields and returns full record', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        day_reset_time: '05:00',
+        updated_at: '2026-01-02T00:00:00.000Z',
+      });
+
+      const result = await repo.update(mockDb, {
+        dayResetTime: '05:00',
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE UserSettings SET'),
+        '05:00',
+        expect.any(String),
+        '1'
+      );
+      expect(result.dayResetTime).toBe('05:00');
+    });
+
+    it('handles boolean fields correctly', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        global_blocking_enabled: 0,
+      });
+
+      const result = await repo.update(mockDb, {
+        globalBlockingEnabled: false,
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('global_blocking_enabled = ?'),
+        0,
+        expect.any(String),
+        '1'
+      );
+      expect(result.globalBlockingEnabled).toBe(false);
+    });
+
+    it('updates multiple fields at once', async () => {
+      (mockDb.runAsync as jest.Mock).mockResolvedValue({
+        changes: 1,
+        lastInsertRowId: 0,
+      });
+      (mockDb.getFirstAsync as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        onboarding_completed: 1,
+        global_blocking_enabled: 0,
+      });
+
+      await repo.update(mockDb, {
+        onboardingCompleted: true,
+        globalBlockingEnabled: false,
+      });
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('onboarding_completed = ?'),
+        1,
+        0,
+        expect.any(String),
+        '1'
+      );
+    });
+  });
+});

--- a/tests/shared/date-utils.test.ts
+++ b/tests/shared/date-utils.test.ts
@@ -1,0 +1,47 @@
+import { getAlignedDate, formatDate } from '../../src/shared/date-utils';
+
+describe('date-utils', () => {
+  describe('formatDate', () => {
+    it('formats a date as YYYY-MM-DD', () => {
+      const date = new Date(2026, 0, 15); // Jan 15, 2026
+      expect(formatDate(date)).toBe('2026-01-15');
+    });
+
+    it('pads single-digit month and day', () => {
+      const date = new Date(2026, 2, 5); // Mar 5, 2026
+      expect(formatDate(date)).toBe('2026-03-05');
+    });
+  });
+
+  describe('getAlignedDate', () => {
+    it('returns current day when time is after reset time', () => {
+      // 10:30 AM with reset at 04:00
+      const timestamp = new Date(2026, 0, 15, 10, 30);
+      expect(getAlignedDate(timestamp, '04:00')).toBe('2026-01-15');
+    });
+
+    it('returns previous day when time is before reset time', () => {
+      // 02:30 AM with reset at 04:00
+      const timestamp = new Date(2026, 0, 15, 2, 30);
+      expect(getAlignedDate(timestamp, '04:00')).toBe('2026-01-14');
+    });
+
+    it('returns current day when time equals reset time', () => {
+      // 04:00 AM with reset at 04:00
+      const timestamp = new Date(2026, 0, 15, 4, 0);
+      expect(getAlignedDate(timestamp, '04:00')).toBe('2026-01-15');
+    });
+
+    it('handles midnight reset time', () => {
+      // 23:59 with reset at 00:00 — after reset, returns current day
+      const late = new Date(2026, 0, 15, 23, 59);
+      expect(getAlignedDate(late, '00:00')).toBe('2026-01-15');
+    });
+
+    it('handles midnight exactly with non-midnight reset', () => {
+      // 00:00 with reset at 04:00 — before reset, returns previous day
+      const midnight = new Date(2026, 0, 15, 0, 0);
+      expect(getAlignedDate(midnight, '04:00')).toBe('2026-01-14');
+    });
+  });
+});

--- a/tests/shared/error-types.test.ts
+++ b/tests/shared/error-types.test.ts
@@ -1,0 +1,72 @@
+import {
+  DatabaseError,
+  ValidationError,
+  PermissionError,
+  NativeBridgeError,
+} from '../../src/shared/error-types';
+
+describe('error-types', () => {
+  describe('DatabaseError', () => {
+    it('extends Error with correct code and name', () => {
+      const error = new DatabaseError('db failed');
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('db failed');
+      expect(error.code).toBe('DATABASE_ERROR');
+      expect(error.name).toBe('DatabaseError');
+    });
+
+    it('accepts a cause option', () => {
+      const cause = new Error('root cause');
+      const error = new DatabaseError('db failed', { cause });
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe('ValidationError', () => {
+    it('extends Error with correct code and name', () => {
+      const error = new ValidationError('invalid input');
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('invalid input');
+      expect(error.code).toBe('VALIDATION_ERROR');
+      expect(error.name).toBe('ValidationError');
+    });
+
+    it('accepts a cause option', () => {
+      const cause = new Error('root cause');
+      const error = new ValidationError('invalid input', { cause });
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe('PermissionError', () => {
+    it('extends Error with correct code and name', () => {
+      const error = new PermissionError('access denied');
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('access denied');
+      expect(error.code).toBe('PERMISSION_ERROR');
+      expect(error.name).toBe('PermissionError');
+    });
+
+    it('accepts a cause option', () => {
+      const cause = new Error('root cause');
+      const error = new PermissionError('access denied', { cause });
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe('NativeBridgeError', () => {
+    it('extends Error with correct code and name', () => {
+      const error = new NativeBridgeError('bridge failed');
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('bridge failed');
+      expect(error.code).toBe('NATIVE_BRIDGE_ERROR');
+      expect(error.name).toBe('NativeBridgeError');
+    });
+
+    it('accepts a cause option', () => {
+      const cause = new Error('root cause');
+      const error = new NativeBridgeError('bridge failed', { cause });
+      expect(error.cause).toBe(cause);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 repositories (SuccessThreshold, OverrideEvent, DailyRecord, UserSettings) completing the full repository layer
- Add shared utility modules: `error-types.ts` (DatabaseError, ValidationError, PermissionError, NativeBridgeError) and `date-utils.ts` (getAlignedDate, formatDate)
- Add domain type files: `calendar-types.ts` (DailyStatus, SuccessThreshold, OverrideEvent, DailyRecord) and `settings-types.ts` (UserSettings)

Closes #32

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm test` — all 104 tests pass (11 suites), including 6 new test files
- [x] `npx eslint . --ext .ts,.tsx` passes clean
- [x] Verify getAlignedDate handles before/after/at reset time and midnight edge cases
- [x] Verify all 4 error classes extend Error with correct code/name properties
- [x] Verify upsert ON CONFLICT behavior for SuccessThreshold and DailyRecord
- [x] Verify UserSettings.get throws DatabaseError when row missing
- [x] Verify UserSettings.update handles partial fields and boolean conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)