### PR TITLE
feat: add settings screen with configurable options and global off switch

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,21 +1,221 @@
-import { View, StyleSheet } from 'react-native';
-import { Text } from 'react-native-paper';
+import { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import {
+  List,
+  Switch,
+  Text,
+  Portal,
+  Dialog,
+  Button,
+  TextInput,
+} from 'react-native-paper';
+import { useRouter } from 'expo-router';
+import { useSettingsStore } from '../../src/settings/settings-store';
+
+const DAY_RESET_TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/;
 
 export default function SettingsScreen() {
+  const router = useRouter();
+  const { settings, isLoading, error, loadSettings, updateDayResetTime, toggleGlobalBlocking } =
+    useSettingsStore();
+
+  const [resetTimeDialogVisible, setResetTimeDialogVisible] = useState(false);
+  const [resetTimeInput, setResetTimeInput] = useState('');
+  const [resetTimeError, setResetTimeError] = useState('');
+
+  const [disableBlockingDialogVisible, setDisableBlockingDialogVisible] =
+    useState(false);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  const handleOpenResetTimeDialog = () => {
+    setResetTimeInput(settings?.dayResetTime ?? '04:00');
+    setResetTimeError('');
+    setResetTimeDialogVisible(true);
+  };
+
+  const handleSaveResetTime = () => {
+    if (!DAY_RESET_TIME_REGEX.test(resetTimeInput)) {
+      setResetTimeError('Enter a valid time in HH:MM 24-hour format');
+      return;
+    }
+    updateDayResetTime(resetTimeInput);
+    setResetTimeDialogVisible(false);
+  };
+
+  const handleToggleGlobalBlocking = (value: boolean) => {
+    if (!value) {
+      setDisableBlockingDialogVisible(true);
+    } else {
+      toggleGlobalBlocking(true);
+    }
+  };
+
+  const handleConfirmDisableBlocking = () => {
+    toggleGlobalBlocking(false);
+    setDisableBlockingDialogVisible(false);
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.centered}>
+        <Text variant="bodyLarge">Loading settings...</Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={styles.container}>
-      <Text variant="headlineMedium">Settings</Text>
-      <Text variant="bodyLarge">App settings will appear here.</Text>
-    </View>
+    <ScrollView style={styles.container}>
+      {error && (
+        <Text style={styles.errorBanner} variant="bodyMedium">
+          {error}
+        </Text>
+      )}
+
+      <List.Section>
+        <List.Subheader>App Management</List.Subheader>
+        <List.Item
+          title="App Selection"
+          description="Choose which apps to monitor"
+          left={(props) => <List.Icon {...props} icon="apps" />}
+          onPress={() => router.push('/app-selection' as never)}
+        />
+        <List.Item
+          title="Enforcement Levels"
+          description="Set blocking strictness per app"
+          left={(props) => <List.Icon {...props} icon="shield-check" />}
+          onPress={() => router.push('/enforcement-levels' as never)}
+        />
+      </List.Section>
+
+      <List.Section>
+        <List.Subheader>Task Management</List.Subheader>
+        <List.Item
+          title="Schedules"
+          description="Configure monitoring schedules"
+          left={(props) => <List.Icon {...props} icon="clock-outline" />}
+          onPress={() => router.push('/schedules' as never)}
+        />
+        <List.Item
+          title="Tasks"
+          description="Manage goal tasks"
+          left={(props) => <List.Icon {...props} icon="checkbox-marked-outline" />}
+          onPress={() => router.push('/tasks' as never)}
+        />
+        <List.Item
+          title="Success Thresholds"
+          description="Define completion criteria"
+          left={(props) => <List.Icon {...props} icon="trophy-outline" />}
+          onPress={() => router.push('/success-thresholds' as never)}
+        />
+      </List.Section>
+
+      <List.Section>
+        <List.Subheader>Display</List.Subheader>
+        <List.Item
+          title="Day Reset Time"
+          description={settings?.dayResetTime ?? '04:00'}
+          left={(props) => <List.Icon {...props} icon="weather-sunset" />}
+          onPress={handleOpenResetTimeDialog}
+        />
+      </List.Section>
+
+      <List.Section>
+        <List.Subheader>System</List.Subheader>
+        <List.Item
+          title="Global Blocking"
+          description={
+            settings?.globalBlockingEnabled ? 'Enabled' : 'Disabled'
+          }
+          left={(props) => <List.Icon {...props} icon="shield-lock" />}
+          right={() => (
+            <Switch
+              value={settings?.globalBlockingEnabled ?? false}
+              onValueChange={handleToggleGlobalBlocking}
+            />
+          )}
+        />
+        <List.Item
+          title="OEM Setup Wizard"
+          description="Configure device-specific permissions"
+          left={(props) => <List.Icon {...props} icon="cellphone-cog" />}
+          onPress={() => router.push('/oem-setup' as never)}
+        />
+      </List.Section>
+
+      <Portal>
+        <Dialog
+          visible={resetTimeDialogVisible}
+          onDismiss={() => setResetTimeDialogVisible(false)}
+        >
+          <Dialog.Title>Day Reset Time</Dialog.Title>
+          <Dialog.Content>
+            <TextInput
+              label="Time (HH:MM, 24h)"
+              value={resetTimeInput}
+              onChangeText={(text) => {
+                setResetTimeInput(text);
+                setResetTimeError('');
+              }}
+              error={!!resetTimeError}
+              keyboardType="numeric"
+            />
+            {resetTimeError ? (
+              <Text style={styles.dialogError} variant="bodySmall">
+                {resetTimeError}
+              </Text>
+            ) : null}
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setResetTimeDialogVisible(false)}>
+              Cancel
+            </Button>
+            <Button onPress={handleSaveResetTime}>Save</Button>
+          </Dialog.Actions>
+        </Dialog>
+
+        <Dialog
+          visible={disableBlockingDialogVisible}
+          onDismiss={() => setDisableBlockingDialogVisible(false)}
+        >
+          <Dialog.Title>Disable Global Blocking?</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              This will stop monitoring and blocking on all apps. Are you sure?
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setDisableBlockingDialogVisible(false)}>
+              Cancel
+            </Button>
+            <Button onPress={handleConfirmDisableBlocking}>Disable</Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  centered: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     padding: 16,
-    gap: 8,
+  },
+  errorBanner: {
+    backgroundColor: '#FDECEA',
+    color: '#B00020',
+    padding: 12,
+    textAlign: 'center',
+  },
+  dialogError: {
+    color: '#B00020',
+    marginTop: 4,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-native": "0.76.7",
         "react-native-paper": "^5.12.5",
         "react-native-safe-area-context": "4.12.0",
-        "react-native-screens": "~4.4.0"
+        "react-native-screens": "~4.4.0",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@babel/core": "^7.25.0",
@@ -16450,6 +16451,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-native": "0.76.7",
     "react-native-paper": "^5.12.5",
     "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.4.0"
+    "react-native-screens": "~4.4.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/src/native-bridge/monitoring-bridge.ts
+++ b/src/native-bridge/monitoring-bridge.ts
@@ -1,0 +1,17 @@
+export interface MonitoringBridge {
+  startMonitoringService(): Promise<void>;
+  stopMonitoringService(): Promise<void>;
+}
+
+export const monitoringBridge: MonitoringBridge = {
+  async startMonitoringService(): Promise<void> {
+    console.warn(
+      'monitoringBridge.startMonitoringService() is a stub — native module not yet implemented'
+    );
+  },
+  async stopMonitoringService(): Promise<void> {
+    console.warn(
+      'monitoringBridge.stopMonitoringService() is a stub — native module not yet implemented'
+    );
+  },
+};

--- a/src/settings/settings-service.ts
+++ b/src/settings/settings-service.ts
@@ -1,0 +1,44 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { UserSettings } from './settings-types';
+import type { MonitoringBridge } from '../native-bridge/monitoring-bridge';
+import * as userSettingsRepository from '../database/repositories/user-settings-repository';
+import { NativeBridgeError } from '../shared/error-types';
+
+export async function loadSettings(db: SQLiteDatabase): Promise<UserSettings> {
+  return userSettingsRepository.get(db);
+}
+
+export async function updateDayResetTime(
+  db: SQLiteDatabase,
+  time: string
+): Promise<UserSettings> {
+  return userSettingsRepository.update(db, { dayResetTime: time });
+}
+
+export async function setGlobalBlocking(
+  db: SQLiteDatabase,
+  enabled: boolean,
+  bridge: MonitoringBridge
+): Promise<UserSettings> {
+  const previous = await userSettingsRepository.get(db);
+  const updated = await userSettingsRepository.update(db, {
+    globalBlockingEnabled: enabled,
+  });
+
+  try {
+    if (enabled) {
+      await bridge.startMonitoringService();
+    } else {
+      await bridge.stopMonitoringService();
+    }
+  } catch (error) {
+    await userSettingsRepository.update(db, {
+      globalBlockingEnabled: previous.globalBlockingEnabled,
+    });
+    throw new NativeBridgeError('Failed to toggle monitoring service', {
+      cause: error,
+    });
+  }
+
+  return updated;
+}

--- a/src/settings/settings-store.ts
+++ b/src/settings/settings-store.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand';
+import type { UserSettings } from './settings-types';
+import * as settingsService from './settings-service';
+import { monitoringBridge } from '../native-bridge/monitoring-bridge';
+import { getDatabase } from '../database/database';
+
+interface SettingsState {
+  settings: UserSettings | null;
+  isLoading: boolean;
+  error: string | null;
+  loadSettings: () => Promise<void>;
+  updateDayResetTime: (time: string) => Promise<void>;
+  toggleGlobalBlocking: (enabled: boolean) => Promise<void>;
+}
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  settings: null,
+  isLoading: false,
+  error: null,
+
+  async loadSettings() {
+    set({ isLoading: true, error: null });
+    try {
+      const db = await getDatabase();
+      const settings = await settingsService.loadSettings(db);
+      set({ settings, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error:
+          error instanceof Error ? error.message : 'Failed to load settings',
+      });
+    }
+  },
+
+  async updateDayResetTime(time: string) {
+    set({ error: null });
+    try {
+      const db = await getDatabase();
+      const settings = await settingsService.updateDayResetTime(db, time);
+      set({ settings });
+    } catch (error) {
+      set({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to update day reset time',
+      });
+    }
+  },
+
+  async toggleGlobalBlocking(enabled: boolean) {
+    const previous = get().settings;
+    if (previous) {
+      set({ settings: { ...previous, globalBlockingEnabled: enabled } });
+    }
+    set({ error: null });
+
+    try {
+      const db = await getDatabase();
+      const settings = await settingsService.setGlobalBlocking(
+        db,
+        enabled,
+        monitoringBridge
+      );
+      set({ settings });
+    } catch (error) {
+      if (previous) {
+        set({ settings: previous });
+      }
+      set({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to toggle global blocking',
+      });
+    }
+  },
+}));

--- a/tests/settings/settings-service.test.ts
+++ b/tests/settings/settings-service.test.ts
@@ -1,0 +1,125 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
+import type { MonitoringBridge } from '../../src/native-bridge/monitoring-bridge';
+import type { UserSettings } from '../../src/settings/settings-types';
+import { NativeBridgeError } from '../../src/shared/error-types';
+import * as settingsService from '../../src/settings/settings-service';
+import * as userSettingsRepository from '../../src/database/repositories/user-settings-repository';
+
+jest.mock('../../src/database/repositories/user-settings-repository');
+
+const mockRepo = userSettingsRepository as jest.Mocked<
+  typeof userSettingsRepository
+>;
+
+const mockDb = {} as SQLiteDatabase;
+
+const sampleSettings: UserSettings = {
+  id: '1',
+  dayResetTime: '04:00',
+  onboardingSurveyResponse: null,
+  onboardingCompleted: true,
+  globalBlockingEnabled: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const mockBridge: jest.Mocked<MonitoringBridge> = {
+  startMonitoringService: jest.fn(),
+  stopMonitoringService: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('settingsService', () => {
+  describe('loadSettings', () => {
+    it('delegates to userSettingsRepository.get', async () => {
+      mockRepo.get.mockResolvedValue(sampleSettings);
+
+      const result = await settingsService.loadSettings(mockDb);
+
+      expect(mockRepo.get).toHaveBeenCalledWith(mockDb);
+      expect(result).toEqual(sampleSettings);
+    });
+  });
+
+  describe('updateDayResetTime', () => {
+    it('calls repository with correct params', async () => {
+      const updated = { ...sampleSettings, dayResetTime: '05:00' };
+      mockRepo.update.mockResolvedValue(updated);
+
+      const result = await settingsService.updateDayResetTime(mockDb, '05:00');
+
+      expect(mockRepo.update).toHaveBeenCalledWith(mockDb, {
+        dayResetTime: '05:00',
+      });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('setGlobalBlocking', () => {
+    it('persists enabled=true and calls startMonitoringService', async () => {
+      const previous = { ...sampleSettings, globalBlockingEnabled: false };
+      const updated = { ...sampleSettings, globalBlockingEnabled: true };
+      mockRepo.get.mockResolvedValue(previous);
+      mockRepo.update.mockResolvedValue(updated);
+      mockBridge.startMonitoringService.mockResolvedValue(undefined);
+
+      const result = await settingsService.setGlobalBlocking(
+        mockDb,
+        true,
+        mockBridge
+      );
+
+      expect(mockRepo.update).toHaveBeenCalledWith(mockDb, {
+        globalBlockingEnabled: true,
+      });
+      expect(mockBridge.startMonitoringService).toHaveBeenCalled();
+      expect(mockBridge.stopMonitoringService).not.toHaveBeenCalled();
+      expect(result).toEqual(updated);
+    });
+
+    it('persists enabled=false and calls stopMonitoringService', async () => {
+      const previous = { ...sampleSettings, globalBlockingEnabled: true };
+      const updated = { ...sampleSettings, globalBlockingEnabled: false };
+      mockRepo.get.mockResolvedValue(previous);
+      mockRepo.update.mockResolvedValue(updated);
+      mockBridge.stopMonitoringService.mockResolvedValue(undefined);
+
+      const result = await settingsService.setGlobalBlocking(
+        mockDb,
+        false,
+        mockBridge
+      );
+
+      expect(mockRepo.update).toHaveBeenCalledWith(mockDb, {
+        globalBlockingEnabled: false,
+      });
+      expect(mockBridge.stopMonitoringService).toHaveBeenCalled();
+      expect(mockBridge.startMonitoringService).not.toHaveBeenCalled();
+      expect(result).toEqual(updated);
+    });
+
+    it('rolls back DB and throws NativeBridgeError on bridge failure', async () => {
+      const previous = { ...sampleSettings, globalBlockingEnabled: true };
+      const updated = { ...sampleSettings, globalBlockingEnabled: false };
+      mockRepo.get.mockResolvedValue(previous);
+      mockRepo.update
+        .mockResolvedValueOnce(updated)
+        .mockResolvedValueOnce(previous);
+      mockBridge.stopMonitoringService.mockRejectedValue(
+        new Error('native crash')
+      );
+
+      await expect(
+        settingsService.setGlobalBlocking(mockDb, false, mockBridge)
+      ).rejects.toThrow(NativeBridgeError);
+
+      expect(mockRepo.update).toHaveBeenCalledTimes(2);
+      expect(mockRepo.update).toHaveBeenLastCalledWith(mockDb, {
+        globalBlockingEnabled: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Build full Settings tab screen with four sections: App Management, Task Management, Display, and System
- Add Zustand settings store (first in codebase), service layer, and native monitoring bridge stub
- Implement day reset time dialog with HH:MM 24h validation and global blocking toggle with confirmation dialog

Closes #33

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 109 tests across 12 suites pass (5 new settings-service tests)
- [x] `npx eslint . --ext .ts,.tsx` passes
- [ ] Manual: verify settings screen renders all four sections in Expo Go
- [ ] Manual: verify day reset time dialog validates input and persists
- [ ] Manual: verify global blocking toggle shows confirmation before disabling

🤖 Generated with [Claude Code](https://claude.com/claude-code)